### PR TITLE
Add content type field with block

### DIFF
--- a/lib/contentful_model/migrations/migration.rb
+++ b/lib/contentful_model/migrations/migration.rb
@@ -5,10 +5,11 @@ module ContentfulModel
         ContentfulModel::Migrations::ContentTypeFactory.create(name, fields, &block)
       end
 
-      def add_content_type_field(content_type_id, name, type)
+      def add_content_type_field(content_type_id, name, type, &block)
         content_type = ContentfulModel::Migrations::ContentTypeFactory.find(content_type_id)
+        field = content_type.field(name, type)
 
-        content_type.field(name, type)
+        yield(field) if block_given?
 
         content_type.save.publish
       end

--- a/spec/migrations/migration_spec.rb
+++ b/spec/migrations/migration_spec.rb
@@ -7,29 +7,69 @@ end
 describe ContentfulModel::Migrations::Migration do
   subject { MockMigration.new }
 
-  it '#create_content_type' do
-    expect(ContentfulModel::Migrations::ContentTypeFactory).to receive(:create)
-
-    subject.create_content_type('foo')
+  before do
+    @mock_content_type = Object.new
+    @mock_field = Object.new
+    allow(ContentfulModel::Migrations::ContentTypeFactory).to receive(:find).with('ct_id') { @mock_content_type }
+    allow(@mock_content_type).to receive(:save) { @mock_content_type }
+    allow(@mock_content_type).to receive(:publish)
+    allow(@mock_content_type).to receive(:field).with('name', :type) { @mock_field }
+    allow(@mock_content_type).to receive(:remove_field).with('name')
   end
 
-  it '#add_content_type_field' do
-    mock_ct = Object.new
-    allow(ContentfulModel::Migrations::ContentTypeFactory).to receive(:find).with('ct_id') { mock_ct }
-    expect(mock_ct).to receive(:field).with('name', :type)
-    expect(mock_ct).to receive(:save) { mock_ct }
-    expect(mock_ct).to receive(:publish)
+  describe "#create_content_type" do
+    it 'creates content type' do
+      expect(ContentfulModel::Migrations::ContentTypeFactory).to receive(:create)
 
-    subject.add_content_type_field('ct_id', 'name', :type)
+      subject.create_content_type('foo')
+    end
   end
 
-  it '#remove_content_type_field' do
-    mock_ct = Object.new
-    allow(ContentfulModel::Migrations::ContentTypeFactory).to receive(:find).with('ct_id') { mock_ct }
-    expect(mock_ct).to receive(:remove_field).with('field_id')
-    expect(mock_ct).to receive(:save) { mock_ct }
-    expect(mock_ct).to receive(:publish)
+  describe '#add_content_type_field' do
+    it 'creates field' do
+      expect(@mock_content_type).to receive(:field)
 
-    subject.remove_content_type_field('ct_id', 'field_id')
+      subject.add_content_type_field('ct_id', 'name', :type)
+    end
+
+    it 'publishes content type' do
+      expect(@mock_content_type).to receive(:publish)
+
+      subject.add_content_type_field('ct_id', 'name', :type)
+    end
+
+    it 'saves content type' do
+      expect(@mock_content_type).to receive(:save)
+
+      subject.add_content_type_field('ct_id', 'name', :type)
+    end
+
+    it 'yields content type' do
+      expect(@mock_field).to receive(:validations=)
+
+      subject.add_content_type_field('ct_id', 'name', :type) do |field|
+        field.validations = []
+      end
+    end
+  end
+
+  describe '#remove_content_type_field' do
+    it 'removes field' do
+      expect(@mock_content_type).to receive(:remove_field).with('name')
+
+      subject.remove_content_type_field('ct_id', 'name')
+    end
+
+    it 'publishes content type' do
+      expect(@mock_content_type).to receive(:publish)
+
+      subject.remove_content_type_field('ct_id', 'name')
+    end
+
+    it 'saves content type' do
+      expect(@mock_content_type).to receive(:save)
+
+      subject.remove_content_type_field('ct_id', 'name')
+    end
   end
 end


### PR DESCRIPTION
Makes `add_content_type_field` behave similarly to `create_content_type`, i.e., allows a block to passed, which is useful for adding things, e.g., validations.